### PR TITLE
Remove activation log

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,10 +6,6 @@ import {
 } from "./util";
 
 export async function activate(context: vscode.ExtensionContext) {
-  console.log(
-    `Congratulations, your extension "${context.extension.packageJSON.displayName}" installed!`
-  );
-
   firstTimeActivation(context);
 
   let activateCommand = vscode.commands.registerCommand(


### PR DESCRIPTION
I love the font, but as an extension developer myself this "Congratulations" message showing up on every single reload gets to be fairly bothersome. I've suggested just deleting it here, but let me know if it would be better to have it display only on the first install instead of each reload, and I'd be happy to alter my PR to do this.

Thanks!